### PR TITLE
Replace Material for MkDocs with Zensical

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -157,11 +157,11 @@ jobs:
       - name: Install Dependencies
         run: pip install -r requirements.txt
       - name: Build User Guide
-        run: mkdocs build
+        run: zensical build
       - name: Upload User Guide Artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
-          path: target/mkdocs
+          path: target/docs
 
   deploy-user-guide:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,7 @@ site_url: https://stefano.codes/junit-converters
 site_author: Stefano Cordio
 site_description: Collection of argument converters for JUnit parameterized testing
 
-site_dir: target/mkdocs
+site_dir: target/docs
 
 # Fail with warnings
 strict: true
@@ -19,6 +19,7 @@ copyright: Copyright &copy; 2025 - 2026 Stefano Cordio
 # Configuration
 theme:
   name: material
+  variant: classic
   features:
     - content.action.edit
     - content.code.copy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-mkdocs==1.6.1
-mkdocs-material[imaging,git]==9.7.7
+zensical==0.0.51


### PR DESCRIPTION
* Closes #40

Blocked by:
- [x] zensical/zensical#46
- [ ] Support for [social cards](https://zensical.org/compatibility/features/#appearance)
- [ ] Support for [module system](https://zensical.org/compatibility/features/#extensions) (hooks currently used for Javadoc generation)